### PR TITLE
Add native Linux support

### DIFF
--- a/SyatiModuleBuildTool/CompileUtility.cs
+++ b/SyatiModuleBuildTool/CompileUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace SyatiModuleBuildTool;
 
@@ -39,13 +40,14 @@ public static class CompileUtility
 
     public static void Compile(string Flags, string Includes, List<(string source, string build)> CompilerTasks, List<(string source, string build)> AssemblerTasks, string SyatiFolderPath)
     {
-        #if _WINDOWS
-        string Compiler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwcceppc.exe")}";
-        string Assembler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwasmeppc.exe")}";
-        #else
-        string Compiler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwcceppc")}";
-        string Assembler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwasmeppc")}";
-        #endif
+        string Compiler, Assembler;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Compiler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwcceppc.exe")}";
+            Assembler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwasmeppc.exe")}";
+        } else {
+            Compiler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwcceppc")}";
+            Assembler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwasmeppc")}";
+        }
         string CompileCommand = $"{string.Join(" ", CompilerFlags)} {Includes}";
         string AssembleCommand = $"{string.Join(" ", CompilerFlags)} {Includes}";
         

--- a/SyatiModuleBuildTool/CompileUtility.cs
+++ b/SyatiModuleBuildTool/CompileUtility.cs
@@ -39,17 +39,16 @@ public static class CompileUtility
 
     public static void Compile(string Flags, string Includes, List<(string source, string build)> CompilerTasks, List<(string source, string build)> AssemblerTasks, string SyatiFolderPath)
     {
+        #if _WINDOWS
         string Compiler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwcceppc.exe")}";
         string Assembler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwasmeppc.exe")}";
-
-
-        #if _WINDOWS
+        #else
+        string Compiler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwcceppc")}";
+        string Assembler = $"{Path.Combine(SyatiFolderPath, "deps/CodeWarrior/mwasmeppc")}";
+        #endif
         string CompileCommand = $"{string.Join(" ", CompilerFlags)} {Includes}";
         string AssembleCommand = $"{string.Join(" ", CompilerFlags)} {Includes}";
-        #else
-        string CompileCommand = $"wine {string.Join(" ", CompilerFlags)} {Includes}";
-        string AssembleCommand = $"wine {string.Join(" ", CompilerFlags)} {Includes}";
-        #endif
+        
 
         for (int i = 0; i < CompilerTasks.Count; i++)
         {

--- a/SyatiModuleBuildTool/Program.cs
+++ b/SyatiModuleBuildTool/Program.cs
@@ -116,7 +116,11 @@ internal class Program
 
         Console.WriteLine();
         Console.WriteLine("Linking...");
+        #if _WINDOWS
         string Kamek = $"{Path.Combine(SyatiFolderPath, "deps/Kamek/Kamek.exe")}";
+        #else 
+        string Kamek = $"{Path.Combine(SyatiFolderPath, "deps/Kamek/Kamek")}";
+        #endif
         List<string> SymbolPaths =
         [
             Path.Combine(SyatiFolderPath, "symbols"),

--- a/SyatiModuleBuildTool/Program.cs
+++ b/SyatiModuleBuildTool/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.InteropServices;
 
 namespace SyatiModuleBuildTool;
 
@@ -116,11 +117,12 @@ internal class Program
 
         Console.WriteLine();
         Console.WriteLine("Linking...");
-        #if _WINDOWS
-        string Kamek = $"{Path.Combine(SyatiFolderPath, "deps/Kamek/Kamek.exe")}";
-        #else 
-        string Kamek = $"{Path.Combine(SyatiFolderPath, "deps/Kamek/Kamek")}";
-        #endif
+        string Kamek;
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            Kamek = $"{Path.Combine(SyatiFolderPath, "deps/Kamek/Kamek.exe")}";
+        } else {
+            Kamek = $"{Path.Combine(SyatiFolderPath, "deps/Kamek/Kamek")}";
+        }
         List<string> SymbolPaths =
         [
             Path.Combine(SyatiFolderPath, "symbols"),


### PR DESCRIPTION
Linux users will have self-contained CW executables if set up through SyatiManager, which lack the .exe extension.