### PR TITLE
Add Disc Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@ A program to build Syati Modules. (Command line tool)
 
 
 ```bat
-SyatiModuleBuildTool.exe <REGION> <Path_To_Syati> <Path_To_Modules_Folder> <Path_To_Output>
+SyatiModuleBuildTool.exe <REGION> <Path_To_Syati> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder> <Path_To_Disc_Output_Folder>
 ```
 - Replace `<REGION>` with one of the following: `USA`, `PAL`, `JPN`, `KOR`, `TWN`. Choose the one that matches your game disc.
 - Replace `<Path_To_Syati>` with the complete path to your Syati folder. If your path has spaces in it, surround it with Quotation Marks "
 - Replace `<Path_To_Modules>` with the complete path to the folder that you put the modules into. If your path has spaces in it, surround it with Quotation Marks "
-- Replace `<Path_To_Output>` with the complete path of the folder that you would like the resulting CustomCode.bin to be saved to. If your path has spaces in it, surround it with Quotation Marks "
+- Replace `<Path_To_Code_Output_Folder>` with the complete path of the folder that you would like the resulting CustomCode.bin to be saved to. If your path has spaces in it, surround it with Quotation Marks "
+- Replace `<Path_To_Disc_Output_Folder>` with the complete path of the folder that you would like the disc files of the modules to be copied to. If your path has spaces in it, surround it with Quotation Marks "
 - If you would like to use **UniBuild**, add `-u` to the end of the command. (Ensure there is a space between the last path and the `-u`)
   > *Note: UniBuild is an alternative method of compiling modules which may result in smaller output binaries. If you have less than 10 modules, you do not need UniBuild.*
 

--- a/README.md
+++ b/README.md
@@ -3,14 +3,19 @@ A program to build Syati Modules. (Command line tool)
 
 
 ```bat
-SyatiModuleBuildTool.exe <REGION> <Path_To_Syati> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder> <Path_To_Disc_Output_Folder>
+SyatiModuleBuildTool.exe <REGION> <Path_To_Syati> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder>
 ```
+
+**Mandatory Arguments:**
 - Replace `<REGION>` with one of the following: `USA`, `PAL`, `JPN`, `KOR`, `TWN`. Choose the one that matches your game disc.
 - Replace `<Path_To_Syati>` with the complete path to your Syati folder. If your path has spaces in it, surround it with Quotation Marks "
 - Replace `<Path_To_Modules>` with the complete path to the folder that you put the modules into. If your path has spaces in it, surround it with Quotation Marks "
 - Replace `<Path_To_Code_Output_Folder>` with the complete path of the folder that you would like the resulting CustomCode.bin to be saved to. If your path has spaces in it, surround it with Quotation Marks "
-- Replace `<Path_To_Disc_Output_Folder>` with the complete path of the folder that you would like the disc files of the modules to be copied to. If your path has spaces in it, surround it with Quotation Marks "
+- Replace `<Path_To_Disc_Output_Folder>` with the complete path of the folder that you would like the disc files of the modules to be copied to. If your path has spaces in it, surround it with Quotation Marks ".
+
+**Optional Arguments:**
+- If you would like to copy disc files, add `-d <Path>` to the end of the command, and replace `<Path>` with the folder you would like to copy the disc files to. If your path has spaces in it, surround it with Quotation Marks ". (Ensure there is a space between the last path and this argument)
 - If you would like to use **UniBuild**, add `-u` to the end of the command. (Ensure there is a space between the last path and the `-u`)
   > *Note: UniBuild is an alternative method of compiling modules which may result in smaller output binaries. If you have less than 10 modules, you do not need UniBuild.*
 
-After running the command, you will be given a **CustomCode.bin** and a **CustomCode.map**.
+After running the command, you will be given a **CustomCode.bin**, a **CustomCode.map**, and if specified, the disc files of all your modules.

--- a/SyatiModuleBuildTool/DiscUtility.cs
+++ b/SyatiModuleBuildTool/DiscUtility.cs
@@ -1,6 +1,32 @@
 ﻿namespace SyatiModuleBuildTool;
 
-public static class DiscUtility
-{
-    // Todo lol
+public static class DiscUtility {
+    public static void CopyAllFiles(List<ModuleInfo> modules, string output) {
+        foreach (ModuleInfo module in modules) {
+            CopyFiles(module, output);
+        }
+    }
+
+    public static void CopyFiles(ModuleInfo module, string output) {
+        var sourceDiscFolder = Path.Combine(module.FolderPath, "disc");
+
+        if (!Directory.Exists(sourceDiscFolder)) {
+            return;
+        }
+
+        Console.WriteLine($"Copying files from {sourceDiscFolder}");
+
+        foreach (var sourcePath in Directory.EnumerateFiles(sourceDiscFolder, "*", SearchOption.AllDirectories)) {
+            var relativePath = Path.GetRelativePath(sourceDiscFolder, sourcePath);
+            var targetPath = Path.Combine(output, relativePath);
+
+            try {
+                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                File.Copy(sourcePath, targetPath, true);
+            }
+            catch (Exception e) {
+                Console.WriteLine($"Error while copying \"{sourceDiscFolder}\": {e.Message}");
+            }
+        }
+    }
 }

--- a/SyatiModuleBuildTool/DiscUtility.cs
+++ b/SyatiModuleBuildTool/DiscUtility.cs
@@ -2,26 +2,29 @@
 
 public static class DiscUtility {
     public static void CopyAllFiles(List<ModuleInfo> modules, string output) {
-        foreach (ModuleInfo module in modules) {
+        foreach (ModuleInfo module in modules)
             CopyFiles(module, output);
-        }
     }
 
     public static void CopyFiles(ModuleInfo module, string output) {
         var sourceDiscFolder = Path.Combine(module.FolderPath, "disc");
 
-        if (!Directory.Exists(sourceDiscFolder)) {
+        if (!Directory.Exists(sourceDiscFolder))
             return;
-        }
 
         Console.WriteLine($"Copying files from {sourceDiscFolder}");
 
-        foreach (var sourcePath in Directory.EnumerateFiles(sourceDiscFolder, "*", SearchOption.AllDirectories)) {
+        var discPaths = Directory.GetFiles(sourceDiscFolder, "*", SearchOption.AllDirectories);
+
+        foreach (var sourcePath in discPaths) {
             var relativePath = Path.GetRelativePath(sourceDiscFolder, sourcePath);
             var targetPath = Path.Combine(output, relativePath);
 
             try {
-                Directory.CreateDirectory(Path.GetDirectoryName(targetPath)!);
+                var targetDirectory = Path.GetDirectoryName(targetPath);
+                if (targetDirectory is not null)
+                    Directory.CreateDirectory(targetDirectory);
+
                 File.Copy(sourcePath, targetPath, true);
             }
             catch (Exception e) {

--- a/SyatiModuleBuildTool/DiscUtility.cs
+++ b/SyatiModuleBuildTool/DiscUtility.cs
@@ -22,7 +22,7 @@ public static class DiscUtility {
 
             try {
                 if (Path.Exists(targetPath))
-                    Console.WriteLine($" - File will replace {targetPath}");
+                    Console.WriteLine($"{sourcePath} will replace {targetPath}");
 
                 var targetDirectory = Path.GetDirectoryName(targetPath);
                 if (targetDirectory is not null)
@@ -31,7 +31,7 @@ public static class DiscUtility {
                 File.Copy(sourcePath, targetPath, true);
             }
             catch (Exception e) {
-                Console.WriteLine($"Error while copying {discFolder}: {e.Message}");
+                Console.WriteLine($"Error while copying \"{discFolder}\": {e.Message}");
             }
         }
     }

--- a/SyatiModuleBuildTool/DiscUtility.cs
+++ b/SyatiModuleBuildTool/DiscUtility.cs
@@ -7,20 +7,23 @@ public static class DiscUtility {
     }
 
     public static void CopyFiles(ModuleInfo module, string output) {
-        var sourceDiscFolder = Path.Combine(module.FolderPath, "disc");
+        var discFolder = Path.Combine(module.FolderPath, "disc");
 
-        if (!Directory.Exists(sourceDiscFolder))
+        if (!Directory.Exists(discFolder))
             return;
 
-        Console.WriteLine($"Copying files from {sourceDiscFolder}");
+        Console.WriteLine($"Copying files from {discFolder}");
 
-        var discPaths = Directory.GetFiles(sourceDiscFolder, "*", SearchOption.AllDirectories);
+        var discPaths = Directory.GetFiles(discFolder, "*", SearchOption.AllDirectories);
 
         foreach (var sourcePath in discPaths) {
-            var relativePath = Path.GetRelativePath(sourceDiscFolder, sourcePath);
+            var relativePath = Path.GetRelativePath(discFolder, sourcePath);
             var targetPath = Path.Combine(output, relativePath);
 
             try {
+                if (Path.Exists(targetPath))
+                    Console.WriteLine($" - File will replace {targetPath}");
+
                 var targetDirectory = Path.GetDirectoryName(targetPath);
                 if (targetDirectory is not null)
                     Directory.CreateDirectory(targetDirectory);
@@ -28,7 +31,7 @@ public static class DiscUtility {
                 File.Copy(sourcePath, targetPath, true);
             }
             catch (Exception e) {
-                Console.WriteLine($"Error while copying \"{sourceDiscFolder}\": {e.Message}");
+                Console.WriteLine($"Error while copying {discFolder}: {e.Message}");
             }
         }
     }

--- a/SyatiModuleBuildTool/Program.cs
+++ b/SyatiModuleBuildTool/Program.cs
@@ -155,7 +155,7 @@ internal class Program
             $"-D{args[0]}"
         ];
         Console.WriteLine();
-        if (args.Last().Equals("-u"))
+        if (args.Any(s => s.Equals("-u")))
             ModuleUtility.CompileAllUnibuild(Modules, Flags, IncludePaths, SyatiFolderPath, args[3], ref AllObjectOutputs);
         else
             ModuleUtility.CompileAllModules(Modules, Flags, IncludePaths, SyatiFolderPath, ref AllObjectOutputs);
@@ -185,17 +185,37 @@ internal class Program
             throw new InvalidOperationException("Linker Failure");
         }
 
-        if (args.Length > 4 && args[4] != "-u") { // Make sure the argument in the position of Path_To_Disc_Output_Folder isn't the unibuild flag
-            Console.WriteLine();
-            Console.WriteLine("Copying disc...");
+        // if (args.Length > 4 && args[4] != "-u") { // Make sure the argument in the position of Path_To_Disc_Output_Folder isn't the unibuild flag
+        if (GetOptionalArgument(ref args, "-d", out var path)) {
+            if (path is not null) {
+                Console.WriteLine();
+                Console.WriteLine("Copying disc...");
 
-            DiscUtility.CopyAllFiles(Modules, args[4]);
+                DiscUtility.CopyAllFiles(Modules, path);
+            }
+            else {
+                Console.WriteLine("A path to copy disc files to was not provided, skipped copying.");
+            }
         }
 
         Console.WriteLine();
         Console.WriteLine("Complete!");
     }
+    static bool GetOptionalArgument(ref string[] args, string flag, out string? str) {
+        for (int i = 0; i < args.Length; i++) {
+            if (args[i] == flag) {
+                if (i + 1 < args.Length)
+                    str = args[i + 1];
+                else
+                    str = null;
 
+                return true;
+            }
+        }
+
+        str = null;
+        return false;
+    }
     static void Help()
     {
         Console.WriteLine(
@@ -203,7 +223,8 @@ internal class Program
             SyatiModuleBuildTool.exe <REGION> <Path_To_Syati_Repo> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder> <Path_To_Disc_Output_Folder>
 
             Extra options:
-            -u      Enable UniBuild. UniBuild can shrink the final .bin file size at the potential cost of debuggability. Should only be used when you have a lot of modules. (10+)
+            -d <Path>  Copy module disc files. To use this option, replace <Path> with the path you want to copy the disc files to.
+            -u         Enable UniBuild. UniBuild can shrink the final .bin file size at the potential cost of debuggability. Should only be used when you have a lot of modules. (10+)
             """);
     }
     static void Error(Exception ex)

--- a/SyatiModuleBuildTool/Program.cs
+++ b/SyatiModuleBuildTool/Program.cs
@@ -155,7 +155,7 @@ internal class Program
             $"-D{args[0]}"
         ];
         Console.WriteLine();
-        if (args.Any(o => o.Equals("-u")))
+        if (args.Last().Equals("-u"))
             ModuleUtility.CompileAllUnibuild(Modules, Flags, IncludePaths, SyatiFolderPath, args[3], ref AllObjectOutputs);
         else
             ModuleUtility.CompileAllModules(Modules, Flags, IncludePaths, SyatiFolderPath, ref AllObjectOutputs);
@@ -185,6 +185,14 @@ internal class Program
             throw new InvalidOperationException("Linker Failure");
         }
 
+        if (args.Length > 4 && args[4] != "-u") { // Make sure the argument in the position of Path_To_Disc_Output_Folder isn't the unibuild flag
+            Console.WriteLine();
+            Console.WriteLine("Copying disc...");
+
+            DiscUtility.CopyAllFiles(Modules, args[4]);
+        }
+
+        Console.WriteLine();
         Console.WriteLine("Complete!");
     }
 
@@ -192,7 +200,7 @@ internal class Program
     {
         Console.WriteLine(
             """
-            SyatiModuleBuildTool.exe <REGION> <Path_To_Syati_Repo> <Path_To_Modules_Folder> <Path_To_Output_Folder>
+            SyatiModuleBuildTool.exe <REGION> <Path_To_Syati_Repo> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder> <Path_To_Disc_Output_Folder>
 
             Extra options:
             -u      Enable UniBuild. UniBuild can shrink the final .bin file size at the potential cost of debuggability. Should only be used when you have a lot of modules. (10+)

--- a/SyatiModuleBuildTool/Program.cs
+++ b/SyatiModuleBuildTool/Program.cs
@@ -185,23 +185,18 @@ internal class Program
             throw new InvalidOperationException("Linker Failure");
         }
 
-        if (GetOptionalArgument(ref args, "-d", out var path)) {
-            if (path is not null) {
-                Console.WriteLine();
-                Console.WriteLine("Copying disc...");
+        if (GetOptionalArgument(ref args, "-d", out var path) && path is not null) {
+            Console.WriteLine();
+            Console.WriteLine("Copying disc...");
 
-                DiscUtility.CopyAllFiles(Modules, path);
-            }
-            else {
-                Console.WriteLine("A path to copy disc files to was not provided, skipped copying.");
-            }
+            DiscUtility.CopyAllFiles(Modules, path);
         }
 
         Console.WriteLine();
         Console.WriteLine("Complete!");
     }
     static bool GetOptionalArgument(ref string[] args, string flag, out string? str) {
-        for (int i = 0; i < args.Length; i++) {
+        for (int i = 4; i < args.Length; i++) {
             if (args[i] == flag) {
                 if (i + 1 < args.Length)
                     str = args[i + 1];
@@ -219,7 +214,7 @@ internal class Program
     {
         Console.WriteLine(
             """
-            SyatiModuleBuildTool.exe <REGION> <Path_To_Syati_Repo> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder> <Path_To_Disc_Output_Folder>
+            SyatiModuleBuildTool.exe <REGION> <Path_To_Syati_Repo> <Path_To_Modules_Folder> <Path_To_Code_Output_Folder>
 
             Extra options:
             -d <Path>  Copy module disc files. To use this option, replace <Path> with the path you want to copy the disc files to.

--- a/SyatiModuleBuildTool/Program.cs
+++ b/SyatiModuleBuildTool/Program.cs
@@ -185,7 +185,6 @@ internal class Program
             throw new InvalidOperationException("Linker Failure");
         }
 
-        // if (args.Length > 4 && args[4] != "-u") { // Make sure the argument in the position of Path_To_Disc_Output_Folder isn't the unibuild flag
         if (GetOptionalArgument(ref args, "-d", out var path)) {
             if (path is not null) {
                 Console.WriteLine();


### PR DESCRIPTION
Users can now input a path to output disc files of modules too.
This also makes a slight change to how the unibuild flag is checked, which prevents some issues.